### PR TITLE
Filter inbound requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ export default {
 		try {
 			const data = JSON.parse(payload);
 
-			if (data.length == 0) {
+			if (data.length === 0) {
 				return new Response(null, {
 					status: 400,
 					statusText: JSON.stringify({ jsonrpc: 2.0, id: null, error: { code: -32600, message: "empty rpc batch"}}),

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,14 @@ export default {
 		const payload = await request.text();
 
 		try {
-			JSON.parse(payload);
+			const data = JSON.parse(payload);
+
+			if (data.length == 0) {
+				return new Response(null, {
+					status: 400,
+					statusText: JSON.stringify({ jsonrpc: 2.0, id: null, error: { code: -32600, message: "empty rpc batch"}}),
+				});
+			}
 		} catch(e) {
 			return new Response(null, {
 				status: 400,

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,16 @@ export default {
 		}
 
 		const payload = await request.text();
+
+		try {
+			JSON.parse(payload);
+		} catch(e) {
+			return new Response(null, {
+				status: 400,
+				statusText: JSON.stringify({ jsonrpc: 2.0, id: null, error: { code: -32700, message: "failed to parse RPC request body"}}),
+			});
+		}
+
 		const proxyRequest = new Request(
 			`https://${pathname === '/' ? rpcNetwork : apiNetwork}.helius.xyz${pathname}?api-key=${
 				env.HELIUS_API_KEY

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,13 @@ export default {
 			return res;
 		}
 
+		if (request.method !== "POST") {
+			return new Response(null, {
+				status: 400,
+				statusText: 'Only POST requests are allowed',
+			});
+		}
+
 		const payload = await request.text();
 		const proxyRequest = new Request(
 			`https://${pathname === '/' ? rpcNetwork : apiNetwork}.helius.xyz${pathname}?api-key=${

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -59,7 +59,6 @@ describe('index', () => {
 		const resp = await worker.fetch(request, originalEnv);
 
 		expect(resp.status).toEqual(400);
-		console.log(resp)
 
 		expect(errorHandler).not.toBeCalled();
 		expect(fetch).not.toBeCalled();

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -18,6 +18,30 @@ describe('index', () => {
 		AWS_CLOUDWATCH_LOG_GROUP: process.env.AWS_CLOUDWATCH_LOG_GROUP as string,
 	};
 
+	test('filters requests with an invalid json',async () => {
+		(errorHandler as jest.Mock).mockImplementation();
+		(fetch as jest.MockedFunction<typeof fetch>).mockImplementation();
+
+		const request = new Request(
+			`https://solana-rpc.web.helium.io/?session-key=${originalEnv.SESSION_KEY}`,
+			{
+				method: 'POST',
+				headers: {
+					Host: 'solana-rpc.web.helium.io',
+				},
+				body: '{"jsonrpc": "2.0", }',
+			}
+		) as unknown as Parameters<typeof worker.fetch>[0];
+
+		const resp = await worker.fetch(request, originalEnv);
+
+		expect(resp.status).toEqual(400);
+		console.log(resp)
+
+		expect(errorHandler).not.toBeCalled();
+		expect(fetch).not.toBeCalled();
+	});
+
 	test('does not invoke errorHandler', async () => {
 		(errorHandler as jest.Mock).mockImplementation();
 		(fetch as jest.MockedFunction<typeof fetch>).mockResolvedValue(

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -18,6 +18,29 @@ describe('index', () => {
 		AWS_CLOUDWATCH_LOG_GROUP: process.env.AWS_CLOUDWATCH_LOG_GROUP as string,
 	};
 
+	test('filters requests with an empty rpc batch',async () => {
+		(errorHandler as jest.Mock).mockImplementation();
+		(fetch as jest.MockedFunction<typeof fetch>).mockImplementation();
+
+		const request = new Request(
+			`https://solana-rpc.web.helium.io/?session-key=${originalEnv.SESSION_KEY}`,
+			{
+				method: 'POST',
+				headers: {
+					Host: 'solana-rpc.web.helium.io',
+				},
+				body: JSON.stringify([]),
+			}
+		) as unknown as Parameters<typeof worker.fetch>[0];
+
+		const resp = await worker.fetch(request, originalEnv);
+
+		expect(resp.status).toEqual(400);
+
+		expect(errorHandler).not.toBeCalled();
+		expect(fetch).not.toBeCalled();
+	});
+
 	test('filters requests with an invalid json',async () => {
 		(errorHandler as jest.Mock).mockImplementation();
 		(fetch as jest.MockedFunction<typeof fetch>).mockImplementation();

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -27,10 +27,11 @@ describe('index', () => {
 		const request = new Request(
 			`https://solana-rpc.web.helium.io/?session-key=${originalEnv.SESSION_KEY}`,
 			{
-				method: 'GET',
+				method: 'POST',
 				headers: {
 					Host: 'solana-rpc.web.helium.io',
 				},
+				body: JSON.stringify({ jsonrpc: 2.0, id: "op-1", method: "getRecentBlockhash" }),
 			}
 		) as unknown as Parameters<typeof worker.fetch>[0];
 
@@ -48,10 +49,11 @@ describe('index', () => {
 		const request = new Request(
 			`https://solana-rpc.web.helium.io/?session-key=${originalEnv.SESSION_KEY}`,
 			{
-				method: 'GET',
+				method: 'POST',
 				headers: {
 					Host: 'solana-rpc.web.helium.io',
 				},
+				body: JSON.stringify({ jsonrpc: 2.0, id: "op-1", method: "getRecentBlockhash" }),
 			}
 		) as unknown as Parameters<typeof worker.fetch>[0];
 


### PR DESCRIPTION
* Only allow POST requests to pass through to underlying RPC.
* Filters Invalid JSON
* Filters empty RPC batches